### PR TITLE
Number of C/C++ files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,4 @@ cython_debug/
 
 # Default report file
 report.xml
+coverage.lcov

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = src

--- a/src/cpp_stats/__init__.py
+++ b/src/cpp_stats/__init__.py
@@ -1,0 +1,1 @@
+from cpp_stats.cpp_stats import *

--- a/src/cpp_stats/cpp_stats.py
+++ b/src/cpp_stats/cpp_stats.py
@@ -1,3 +1,12 @@
+'''
+Main class for creating report about quality of C/C++ repository.
+'''
+
+from pathlib import Path
+from datetime import datetime
+
+from cpp_stats.file_sieve import sieve_c_cxx_files
+
 class CppStats(object):
     '''
     Class for calculating C++ metrics in a given repository.
@@ -13,6 +22,7 @@ class CppStats(object):
 
         self._path_to_repo = path_to_repo
         self._available_metrics = [
+            'NUMBER_OF_C_C++_FILES',
             'NUMBER_OF_CLASSES',
             'MEAN_NUMBER_OF_METHODS_PER_CLASS',
             'MAX_NUMBER_OF_METHODS_PER_CLASS',
@@ -41,6 +51,8 @@ class CppStats(object):
             'LCC',
             'CAMC',
             ]
+        
+        self._files = sieve_c_cxx_files(Path(self._path_to_repo))
 
     def list(self) -> list[str]:
         '''
@@ -56,8 +68,9 @@ class CppStats(object):
         Parameters:
         metric_name (str): Metric name.
         '''
-
-        pass
+        if metric_name == 'NUMBER_OF_C_C++_FILES':
+            return len(self._files)
+        return None
 
     def as_xml(self):
         '''
@@ -66,7 +79,11 @@ class CppStats(object):
 
         return (
             f'<report>\n'
-            f'    <repository name="path">'
-            f'{self._path_to_repo}</repository>\n'
-            f'</report>'
+            f'    <report-time>{datetime.now().strftime("%d.%m.%Y")}</report-time>\n'
+            f'    <repository-path>{self._path_to_repo}</repository-path>\n'
+            f'    <metrics>\n'
+            f'        <metric name="NUMBER_OF_C_C++_FILES">'
+            f'{self.metric("NUMBER_OF_C_C++_FILES")}</metric>\n'
+            f'    </metrics>\n'
+            f'</report>\n'
         )

--- a/src/cpp_stats/cpp_stats.py
+++ b/src/cpp_stats/cpp_stats.py
@@ -7,7 +7,7 @@ from datetime import datetime
 
 from cpp_stats.file_sieve import sieve_c_cxx_files
 
-class CppStats(object):
+class CppStats:
     '''
     Class for calculating C++ metrics in a given repository.
     '''

--- a/src/cpp_stats/cpp_stats.py
+++ b/src/cpp_stats/cpp_stats.py
@@ -51,7 +51,7 @@ class CppStats(object):
             'LCC',
             'CAMC',
             ]
-        
+
         self._files = sieve_c_cxx_files(Path(self._path_to_repo))
 
     def list(self) -> list[str]:

--- a/src/cpp_stats/cpp_stats.py
+++ b/src/cpp_stats/cpp_stats.py
@@ -1,5 +1,3 @@
-from typing import List
-
 class CppStats(object):
     '''
     Class for calculating C++ metrics in a given repository.
@@ -12,7 +10,7 @@ class CppStats(object):
         Parameters:
         path_to_repo (str): Path to the repository.
         '''
-        
+
         self._path_to_repo = path_to_repo
         self._available_metrics = [
             'NUMBER_OF_CLASSES',
@@ -43,14 +41,14 @@ class CppStats(object):
             'LCC',
             'CAMC',
             ]
-    
+
     def list(self) -> list[str]:
         '''
         Returns list of all available metrics.
         '''
-        
+
         return self._available_metrics
-    
+
     def metric(self, metric_name: str):
         '''
         Returns metric by name.
@@ -58,14 +56,14 @@ class CppStats(object):
         Parameters:
         metric_name (str): Metric name.
         '''
-        
+
         pass
-    
+
     def as_xml(self):
         '''
         Returns report with all metrics as XML for a given repository.
         '''
-        
+
         return (
             f'<report>\n'
             f'    <repository name="path">'

--- a/src/cpp_stats/file_sieve.py
+++ b/src/cpp_stats/file_sieve.py
@@ -42,10 +42,19 @@ def sieve_c_cxx_files(path_to_repo: str) -> list[Path] | None:
 _possible_extensions = ['*.h', '*.hpp', '*.C', '*.cc', '*.cpp',
                         '*.CPP', '*.c++', '*.cp', '*.cxx']
 
-def _locate_file(path_to_search: Path, file_to_find: str,
-                 banned_dirs: list[Path]) -> list[Path] | None:
+def _locate_file(path_to_search: Path, pattern: str,
+                 banned_dirs: list[Path]) -> list[Path]:
+    '''
+    Finds all files that match `pattern` inside `path_to_search` directory
+    ignoring `banned_dirs`
+    
+    Parameters:
+    `path_to_search` (`pathlib.Path`): path to starting directory
+    `pattern` (`str`): pattern to find
+    `banned_dirs` (`list[pathlib.Path]`): directories that will be ignored during search
+    '''
     paths = []
-    for entry in path_to_search.rglob(file_to_find):
+    for entry in path_to_search.rglob(pattern):
         is_inside_banned_dirs = False
         for b_dir in banned_dirs:
             if entry.is_relative_to(b_dir):
@@ -56,6 +65,12 @@ def _locate_file(path_to_search: Path, file_to_find: str,
     return paths
 
 def _get_git_modules_dirs(git_modules_path: Path) -> list[Path]:
+    '''
+    Finds all directories that listed in `.gitmodules` file located at `git_modules_path`
+    
+    Parameters:
+    `git_modules_path` (`pathlib.Path`): path to `.gitmodules`
+    '''
     parent_directory = git_modules_path.parent
     paths = []
     with open(git_modules_path, 'r') as f:
@@ -68,6 +83,12 @@ def _get_git_modules_dirs(git_modules_path: Path) -> list[Path]:
     return paths
 
 def _get_git_ignore_dirs(git_ignore_path: Path) -> list[Path]:
+    '''
+    Finds all directories that listed in `.gitignore` file located at `git_ignore_path`
+    
+    Parameters:
+    `git_ignore_path` (`pathlib.Path`): path to `.gitignore`
+    '''
     parent_directory = git_ignore_path.parent
     paths = []
     with open(git_ignore_path, 'r') as f:

--- a/src/cpp_stats/file_sieve.py
+++ b/src/cpp_stats/file_sieve.py
@@ -39,7 +39,7 @@ def sieve_c_cxx_files(path_to_repo: str) -> list[Path] | None:
     c_cxx_files = set(c_cxx_files)
     return list(c_cxx_files)
 
-_possible_extensions = ['*.h', '*.hpp', '*.C', '*.cc', '*.cpp',
+_possible_extensions = ['*.h', '*.hpp', '*.c', '*.C', '*.cc', '*.cpp',
                         '*.CPP', '*.c++', '*.cp', '*.cxx']
 
 def _locate_file(path_to_search: Path, pattern: str,

--- a/src/cpp_stats/file_sieve.py
+++ b/src/cpp_stats/file_sieve.py
@@ -43,10 +43,10 @@ def _get_git_modules_dirs(git_modules_path: Path) -> list[Path]:
     paths = []
     with open(git_modules_path, 'r') as f:
         while (line := f.readline()):
-            line = line.lstrip()
+            line = line.lstrip().rstrip()
             if not line.startswith('path = '):
                 continue
-            path_value = line[line.find('='):].lstrip()
+            path_value = line[line.find('=') + 1:].lstrip()
             paths.append(parent_directory.joinpath(path_value))
     return paths
 
@@ -60,6 +60,10 @@ def _get_git_ignore_dirs(git_ignore_path: Path) -> list[Path]:
                 continue
             if line[0] == '#':
                 continue
+            if line[-1] == '\n':
+                line = line[:-1]
+            if line[-1] == '\\' or line[-1] == '/':
+                line = line[:-1]
             p = parent_directory.joinpath(line)
             if p.is_dir():
                 paths.append(p)

--- a/src/cpp_stats/file_sieve.py
+++ b/src/cpp_stats/file_sieve.py
@@ -1,0 +1,64 @@
+'''
+Modules that sieves all files that are specified in .gitignore 
+or are located inside ignored directories, which are listed in
+.gitignore or .gitmodules
+'''
+
+from pathlib import Path
+
+def sieve_c_cxx_files(path_to_repo: str) -> list[Path] | None:
+    '''
+    Returns list of C/C++ files, what have matching extensions: 
+    `.h`, `.hpp`, `.C`, `.cc`, `.cpp`, `.CPP`, `.c++`, `.cp`, or `.cxx`.
+    
+    Files that located in directories specified in `.gitignore` or `.gitmodules` are ignored.
+    
+    Parameters:
+    path_to_repo (str): Path to the repository.
+    '''
+    if path_to_repo is None:
+        return None
+    return []
+
+_possible_extensions = ['*.h', '*.hpp', '*.C', '*.cc', '*.cpp',
+                        '*.CPP', '*.c++', '*.cp', '*.cxx']
+
+def _locate_file(path_to_search: Path, file_to_find: str,
+                 banned_dirs: list[Path]) -> list[Path] | None:
+    paths = []
+    for entry in path_to_search.rglob(file_to_find):
+        is_inside_banned_dirs = False
+        for b_dir in banned_dirs:
+            if entry.is_relative_to(b_dir):
+                is_inside_banned_dirs = True
+                break
+        if not is_inside_banned_dirs:
+            paths.append(entry)
+    return paths
+
+def _get_git_modules_dirs(git_modules_path: Path) -> list[Path]:
+    parent_directory = git_modules_path.parent
+    paths = []
+    with open(git_modules_path, 'r') as f:
+        while (line := f.readline()):
+            line = line.lstrip()
+            if not line.startswith('path = '):
+                continue
+            path_value = line[line.find('='):].lstrip()
+            paths.append(parent_directory.joinpath(path_value))
+    return paths
+
+def _get_git_ignore_dirs(git_ignore_path: Path) -> list[Path]:
+    parent_directory = git_ignore_path.parent
+    paths = []
+    with open(git_ignore_path, 'r') as f:
+        while (line := f.readline()):
+            line = line.lstrip()
+            if len(line) == 0:
+                continue
+            if line[0] == '#':
+                continue
+            p = parent_directory.joinpath(line)
+            if p.is_dir():
+                paths.append(p)
+    return paths

--- a/src/cpp_stats/file_sieve.py
+++ b/src/cpp_stats/file_sieve.py
@@ -9,9 +9,11 @@ from pathlib import Path
 def sieve_c_cxx_files(path_to_repo: str) -> list[Path] | None:
     '''
     Returns list of C/C++ files, what have matching extensions: 
-    `.h`, `.hpp`, `.C`, `.cc`, `.cpp`, `.CPP`, `.c++`, `.cp`, or `.cxx`.
+    `.h`, `.hpp`, `.C`, `.cc`, `.cpp`, `.CPP`, `.c++`, `.cp`, 
+    or `.cxx`.
     
-    Files that located in directories specified in `.gitignore` or `.gitmodules` are ignored.
+    Files that located in directories specified in `.gitignore` 
+    or `.gitmodules` are ignored.
     
     Parameters:
     path_to_repo (str): Path to the repository.

--- a/src/cpp_stats/file_sieve.py
+++ b/src/cpp_stats/file_sieve.py
@@ -1,7 +1,7 @@
 '''
-Modules that sieves all files that are specified in .gitignore 
-or are located inside ignored directories, which are listed in
-.gitignore or .gitmodules
+Module that sieves all files that are specified in `.gitignore` 
+or located inside ignored directories, which are listed in
+`.gitignore` as ignored or `.gitmodules` as submodules.
 '''
 
 from pathlib import Path
@@ -46,12 +46,12 @@ def _locate_file(path_to_search: Path, pattern: str,
                  banned_dirs: list[Path]) -> list[Path]:
     '''
     Finds all files that match `pattern` inside `path_to_search` directory
-    ignoring `banned_dirs`
+    ignoring `banned_dirs`.
     
     Parameters:
-    `path_to_search` (`pathlib.Path`): path to starting directory
-    `pattern` (`str`): pattern to find
-    `banned_dirs` (`list[pathlib.Path]`): directories that will be ignored during search
+    `path_to_search` (`pathlib.Path`): path to starting directory.
+    `pattern` (`str`): pattern to find.
+    `banned_dirs` (`list[pathlib.Path]`): directories that will be ignored during search.
     '''
     paths = []
     for entry in path_to_search.rglob(pattern):
@@ -66,10 +66,10 @@ def _locate_file(path_to_search: Path, pattern: str,
 
 def _get_git_modules_dirs(git_modules_path: Path) -> list[Path]:
     '''
-    Finds all directories that listed in `.gitmodules` file located at `git_modules_path`
+    Finds all directories that listed in `.gitmodules` file located at `git_modules_path`.
     
     Parameters:
-    `git_modules_path` (`pathlib.Path`): path to `.gitmodules`
+    `git_modules_path` (`pathlib.Path`): path to `.gitmodules`.
     '''
     parent_directory = git_modules_path.parent
     paths = []
@@ -84,10 +84,10 @@ def _get_git_modules_dirs(git_modules_path: Path) -> list[Path]:
 
 def _get_git_ignore_dirs(git_ignore_path: Path) -> list[Path]:
     '''
-    Finds all directories that listed in `.gitignore` file located at `git_ignore_path`
+    Finds all directories that listed in `.gitignore` file located at `git_ignore_path`.
     
     Parameters:
-    `git_ignore_path` (`pathlib.Path`): path to `.gitignore`
+    `git_ignore_path` (`pathlib.Path`): path to `.gitignore`.
     '''
     parent_directory = git_ignore_path.parent
     paths = []

--- a/src/cpp_stats/file_sieve.py
+++ b/src/cpp_stats/file_sieve.py
@@ -20,7 +20,24 @@ def sieve_c_cxx_files(path_to_repo: str) -> list[Path] | None:
     '''
     if path_to_repo is None:
         return None
-    return []
+
+    submodules_paths = _locate_file(path_to_repo, '.gitmodules', [])
+    submodules_dirs = []
+    for p in submodules_paths:
+        submodules_dirs += _get_git_modules_dirs(p)
+
+    gitignore_paths = _locate_file(path_to_repo, '.gitignore', submodules_dirs)
+    gitignore_dirs = []
+    for p in gitignore_paths:
+        gitignore_dirs += _get_git_ignore_dirs(p)
+
+    banned_dirs = submodules_dirs + gitignore_dirs
+
+    c_cxx_files = []
+    for ext in _possible_extensions:
+        c_cxx_files += _locate_file(path_to_repo, ext, banned_dirs)
+    c_cxx_files = set(c_cxx_files)
+    return list(c_cxx_files)
 
 _possible_extensions = ['*.h', '*.hpp', '*.C', '*.cc', '*.cpp',
                         '*.CPP', '*.c++', '*.cp', '*.cxx']

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,60 @@
+from pathlib import Path
+import pytest
+
+def rename_git_ignore_and_modules(repo_path: Path, to_test: bool = True):
+    '''
+    Renames `test.gitignore` to `.gitignore` and 
+    `test.gitmodules` to `.gitmodules` if `to_test == False` or
+    renames `.gitignore` to `test.gitignore` and 
+    `.gitmodules` to `test.gitmodules` if `to_test == True`
+    '''
+    if to_test:
+        for entry in repo_path.rglob('.gitignore'):
+            entry.rename(entry.parent.joinpath('test.gitignore'))
+        for entry in repo_path.rglob('.gitmodules'):
+            entry.rename(entry.parent.joinpath('test.gitmodules'))
+    else:
+        for entry in repo_path.rglob('test.gitignore'):
+            entry.rename(entry.parent.joinpath('.gitignore'))
+        for entry in repo_path.rglob('test.gitmodules'):
+            entry.rename(entry.parent.joinpath('.gitmodules'))
+
+@pytest.fixture
+def repo():
+    '''
+    Returns path to test repository located at `/tests/data/repo`
+    '''
+    repo_path = Path('./tests/data/repo')
+    rename_git_ignore_and_modules(repo_path, False)
+    yield repo_path
+    rename_git_ignore_and_modules(repo_path, True)
+
+@pytest.fixture
+def repo_with_gitignore():
+    '''
+    Returns path to test repository located at `/tests/data/repo_with_gitignore`
+    '''
+    repo_path = Path('./tests/data/repo_with_gitignore')
+    rename_git_ignore_and_modules(repo_path, False)
+    yield repo_path
+    rename_git_ignore_and_modules(repo_path, True)
+
+@pytest.fixture
+def repo_with_2gitignore():
+    '''
+    Returns path to test repository located at `/tests/data/repo_with_2gitignore`
+    '''
+    repo_path = Path('./tests/data/repo_with_2gitignore')
+    rename_git_ignore_and_modules(repo_path, False)
+    yield repo_path
+    rename_git_ignore_and_modules(repo_path, True)
+
+@pytest.fixture
+def repo_with_ignr_modules():
+    '''
+    Returns path to test repository located at `/tests/data/repo_with_ignr_modules`
+    '''
+    repo_path = Path('./tests/data/repo_with_ignr_modules')
+    rename_git_ignore_and_modules(repo_path, False)
+    yield repo_path
+    rename_git_ignore_and_modules(repo_path, True)

--- a/tests/data/repo/main.cpp
+++ b/tests/data/repo/main.cpp
@@ -1,0 +1,6 @@
+#include <iostream>
+
+int main() {
+    std::cout << "Hello world!\n";
+    return 0;
+}

--- a/tests/data/repo_with_2gitignore/folder/ignored_dir/class.hpp
+++ b/tests/data/repo_with_2gitignore/folder/ignored_dir/class.hpp
@@ -1,0 +1,4 @@
+class MyClass {
+public:
+    void SayHello() const;
+};

--- a/tests/data/repo_with_2gitignore/folder/test.gitignore
+++ b/tests/data/repo_with_2gitignore/folder/test.gitignore
@@ -1,0 +1,1 @@
+ignored_dir/

--- a/tests/data/repo_with_2gitignore/ignored_dir/class.hpp
+++ b/tests/data/repo_with_2gitignore/ignored_dir/class.hpp
@@ -1,0 +1,4 @@
+class MyClass {
+public:
+    void SayHello() const;
+};

--- a/tests/data/repo_with_2gitignore/main.cpp
+++ b/tests/data/repo_with_2gitignore/main.cpp
@@ -1,0 +1,6 @@
+#include <iostream>
+
+int main() {
+    std::cout << "Hello world!\n";
+    return 0;
+}

--- a/tests/data/repo_with_2gitignore/test.gitignore
+++ b/tests/data/repo_with_2gitignore/test.gitignore
@@ -1,0 +1,1 @@
+ignored_dir/

--- a/tests/data/repo_with_gitignore/ignored_dir/class.hpp
+++ b/tests/data/repo_with_gitignore/ignored_dir/class.hpp
@@ -1,0 +1,4 @@
+class MyClass {
+public:
+    void SayHello() const;
+};

--- a/tests/data/repo_with_gitignore/main.cpp
+++ b/tests/data/repo_with_gitignore/main.cpp
@@ -1,0 +1,6 @@
+#include <iostream>
+
+int main() {
+    std::cout << "Hello world!\n";
+    return 0;
+}

--- a/tests/data/repo_with_gitignore/test.gitignore
+++ b/tests/data/repo_with_gitignore/test.gitignore
@@ -1,0 +1,1 @@
+ignored_dir/

--- a/tests/data/repo_with_gitignore/test.gitignore
+++ b/tests/data/repo_with_gitignore/test.gitignore
@@ -1,1 +1,3 @@
 ignored_dir/
+
+# comment

--- a/tests/data/repo_with_ignr_modules/ignored_dir/class.hpp
+++ b/tests/data/repo_with_ignr_modules/ignored_dir/class.hpp
@@ -1,0 +1,4 @@
+class MyClass {
+public:
+    void SayHello() const;
+};

--- a/tests/data/repo_with_ignr_modules/main.cpp
+++ b/tests/data/repo_with_ignr_modules/main.cpp
@@ -1,0 +1,6 @@
+#include <iostream>
+
+int main() {
+    std::cout << "Hello world!\n";
+    return 0;
+}

--- a/tests/data/repo_with_ignr_modules/src/class.hpp
+++ b/tests/data/repo_with_ignr_modules/src/class.hpp
@@ -1,0 +1,4 @@
+class MyClass {
+public:
+    void SayHello() const;
+};

--- a/tests/data/repo_with_ignr_modules/src/serial_port.c
+++ b/tests/data/repo_with_ignr_modules/src/serial_port.c
@@ -1,0 +1,1 @@
+// Some C code for connecting to serial port

--- a/tests/data/repo_with_ignr_modules/submodule1/class1.hpp
+++ b/tests/data/repo_with_ignr_modules/submodule1/class1.hpp
@@ -1,0 +1,4 @@
+class MyClass {
+public:
+    void SayHello() const;
+};

--- a/tests/data/repo_with_ignr_modules/submodule2/class2.hpp
+++ b/tests/data/repo_with_ignr_modules/submodule2/class2.hpp
@@ -1,0 +1,4 @@
+class MyClass {
+public:
+    void SayHello() const;
+};

--- a/tests/data/repo_with_ignr_modules/test.gitignore
+++ b/tests/data/repo_with_ignr_modules/test.gitignore
@@ -1,0 +1,1 @@
+ignored_dir/

--- a/tests/data/repo_with_ignr_modules/test.gitmodules
+++ b/tests/data/repo_with_ignr_modules/test.gitmodules
@@ -1,0 +1,6 @@
+[submodule "submodule1"]
+	path = submodule1
+	url = https://gitlab.com/submodule1
+[submodule "submodule2"]
+	path = submodule2
+	url = https://github.com/submodule2

--- a/tests/test_cpp_stats.py
+++ b/tests/test_cpp_stats.py
@@ -32,7 +32,7 @@ def test_number_of_c_cxx_files_3(repo_with_gitignore: Path):
 
 def test_number_of_c_cxx_files_4(repo_with_ignr_modules: Path):
     stats = CppStats(str(repo_with_ignr_modules))
-    expected = 2
+    expected = 3
 
     actual = stats.metric('NUMBER_OF_C_C++_FILES')
 

--- a/tests/test_cpp_stats.py
+++ b/tests/test_cpp_stats.py
@@ -1,0 +1,39 @@
+'''
+Tests for cpp_stats main class.
+'''
+from pathlib import Path
+
+from cpp_stats.cpp_stats import CppStats
+
+def test_number_of_c_cxx_files_1(repo: Path):
+    stats = CppStats(str(repo))
+    expected = 1
+
+    actual = stats.metric('NUMBER_OF_C_C++_FILES')
+
+    assert expected == actual
+
+def test_number_of_c_cxx_files_2(repo_with_2gitignore: Path):
+    stats = CppStats(str(repo_with_2gitignore))
+    expected = 1
+
+    actual = stats.metric('NUMBER_OF_C_C++_FILES')
+
+    assert expected == actual
+
+def test_number_of_c_cxx_files_3(repo_with_gitignore: Path):
+    stats = CppStats(str(repo_with_gitignore))
+    expected = 1
+
+    actual = stats.metric('NUMBER_OF_C_C++_FILES')
+
+    assert expected == actual
+
+
+def test_number_of_c_cxx_files_4(repo_with_ignr_modules: Path):
+    stats = CppStats(str(repo_with_ignr_modules))
+    expected = 2
+
+    actual = stats.metric('NUMBER_OF_C_C++_FILES')
+
+    assert expected == actual

--- a/tests/test_file_sieve.py
+++ b/tests/test_file_sieve.py
@@ -3,77 +3,10 @@ Tests module file_sieve.py
 '''
 
 from pathlib import Path
-import pytest
+
+from utils.asserts import assert_lists_equal_unordered
 
 import cpp_stats.file_sieve
-
-def assert_lists_equal_unordered(expected, actual):
-    '''
-    Asserts that two lists contain same elements.
-    
-    Parameters:
-    `expected` (list): Expected list.
-    `actual` (list): List to check.
-    '''
-    assert sorted(expected) == sorted(actual), f"Expected: {expected}, Actual: {actual}"
-
-def rename_git_ignore_and_modules(repo_path: Path, to_test: bool = True):
-    '''
-    Renames `test.gitignore` to `.gitignore` and 
-    `test.gitmodules` to `.gitmodules` if `to_test == False` or
-    renames `.gitignore` to `test.gitignore` and 
-    `.gitmodules` to `test.gitmodules` if `to_test == True`
-    '''
-    if to_test:
-        for entry in repo_path.rglob('.gitignore'):
-            entry.rename(entry.parent.joinpath('test.gitignore'))
-        for entry in repo_path.rglob('.gitmodules'):
-            entry.rename(entry.parent.joinpath('test.gitmodules'))
-    else:
-        for entry in repo_path.rglob('test.gitignore'):
-            entry.rename(entry.parent.joinpath('.gitignore'))
-        for entry in repo_path.rglob('test.gitmodules'):
-            entry.rename(entry.parent.joinpath('.gitmodules'))
-
-@pytest.fixture
-def repo():
-    '''
-    Returns path to test repository located at `/tests/data/repo`
-    '''
-    repo_path = Path('./tests/data/repo')
-    rename_git_ignore_and_modules(repo_path, False)
-    yield repo_path
-    rename_git_ignore_and_modules(repo_path, True)
-
-@pytest.fixture
-def repo_with_gitignore():
-    '''
-    Returns path to test repository located at `/tests/data/repo_with_gitignore`
-    '''
-    repo_path = Path('./tests/data/repo_with_gitignore')
-    rename_git_ignore_and_modules(repo_path, False)
-    yield repo_path
-    rename_git_ignore_and_modules(repo_path, True)
-
-@pytest.fixture
-def repo_with_2gitignore():
-    '''
-    Returns path to test repository located at `/tests/data/repo_with_2gitignore`
-    '''
-    repo_path = Path('./tests/data/repo_with_2gitignore')
-    rename_git_ignore_and_modules(repo_path, False)
-    yield repo_path
-    rename_git_ignore_and_modules(repo_path, True)
-
-@pytest.fixture
-def repo_with_ignr_modules():
-    '''
-    Returns path to test repository located at `/tests/data/repo_with_ignr_modules`
-    '''
-    repo_path = Path('./tests/data/repo_with_ignr_modules')
-    rename_git_ignore_and_modules(repo_path, False)
-    yield repo_path
-    rename_git_ignore_and_modules(repo_path, True)
 
 def test_find_gitignore_1(repo: Path):
     '''

--- a/tests/test_file_sieve.py
+++ b/tests/test_file_sieve.py
@@ -1,22 +1,25 @@
-from pathlib import Path
-import src.cpp_stats.file_sieve
-
 import pytest
+from pathlib import Path
 
-def rename_gitignore(repo_path: Path, to_test: bool = True):
+import cpp_stats.file_sieve
+
+def rename_git_ignore_and_modules(repo_path: Path, to_test: bool = True):
     '''
-    Renames `test.gitignore` to `.gitignore` if `to_test == False` or
-    
-    renames `.gitignore` to `test.gitignore` if `to_test == True`
+    Renames `test.gitignore` to `.gitignore` and 
+    `test.gitmodules` to `.gitmodules` if `to_test == False` or
+    renames `.gitignore` to `test.gitignore` and 
+    `.gitmodules` to `test.gitmodules` if `to_test == True`
     '''
     if to_test:
-        for entry in repo_path.iterdir():
-            if entry.name == '.gitignore':
-                entry.rename(repo_path.joinpath('test.gitignore'))
+        for entry in repo_path.rglob('.gitignore'):
+            entry.rename(entry.parent.joinpath('test.gitignore'))
+        for entry in repo_path.rglob('.gitmodules'):
+            entry.rename(entry.parent.joinpath('test.gitmodules'))
     else:
-        for entry in repo_path.iterdir():
-            if entry.name == 'test.gitignore':
-                entry.rename(repo_path.joinpath('.gitignore'))
+        for entry in repo_path.rglob('test.gitignore'):
+            entry.rename(entry.parent.joinpath('.gitignore'))
+        for entry in repo_path.rglob('test.gitmodules'):
+            entry.rename(entry.parent.joinpath('.gitmodules'))
 
 @pytest.fixture
 def repo():
@@ -24,9 +27,9 @@ def repo():
     Returns path to test repository located at `/tests/data/repo`
     '''
     repo_path = Path('./tests/data/repo')
-    rename_gitignore(repo_path, False)
+    rename_git_ignore_and_modules(repo_path, False)
     yield repo_path
-    rename_gitignore(repo_path, True)
+    rename_git_ignore_and_modules(repo_path, True)
 
 @pytest.fixture
 def repo_with_gitignore():
@@ -34,9 +37,29 @@ def repo_with_gitignore():
     Returns path to test repository located at `/tests/data/repo_with_gitignore`
     '''
     repo_path = Path('./tests/data/repo_with_gitignore')
-    rename_gitignore(repo_path, False)
+    rename_git_ignore_and_modules(repo_path, False)
     yield repo_path
-    rename_gitignore(repo_path, True)
+    rename_git_ignore_and_modules(repo_path, True)
+
+@pytest.fixture
+def repo_with_2gitignore():
+    '''
+    Returns path to test repository located at `/tests/data/repo_with_2gitignore`
+    '''
+    repo_path = Path('./tests/data/repo_with_2gitignore')
+    rename_git_ignore_and_modules(repo_path, False)
+    yield repo_path
+    rename_git_ignore_and_modules(repo_path, True)
+
+@pytest.fixture
+def repo_with_ignr_modules():
+    '''
+    Returns path to test repository located at `/tests/data/repo_with_ignr_modules`
+    '''
+    repo_path = Path('./tests/data/repo_with_ignr_modules')
+    rename_git_ignore_and_modules(repo_path, False)
+    yield repo_path
+    rename_git_ignore_and_modules(repo_path, True)
 
 def test_find_gitignore_1(repo: Path):
     '''
@@ -46,7 +69,7 @@ def test_find_gitignore_1(repo: Path):
     file_to_locate = '.gitignore'
     correct = []
 
-    result = src.cpp_stats.file_sieve._locate_file(repo, file_to_locate, [])
+    result = cpp_stats.file_sieve._locate_file(repo, file_to_locate, [])
 
     assert correct == result
 
@@ -60,6 +83,79 @@ def test_find_gitignore_2(repo_with_gitignore: Path):
         Path('./tests/data/repo_with_gitignore/.gitignore')
     ]
 
-    result = src.cpp_stats.file_sieve._locate_file(repo_with_gitignore, file_to_locate, [])
+    result = cpp_stats.file_sieve._locate_file(repo_with_gitignore, file_to_locate, [])
+
+    assert correct == result
+
+def test_find_gitignore_3(repo_with_2gitignore: Path):
+    '''
+    Tests that in repository with .gitignore 
+    function src.cpp_stats.file_sieve._locate_file finds exactly one
+    '''
+    file_to_locate = '.gitignore'
+    correct = [
+        Path('./tests/data/repo_with_2gitignore/.gitignore'),
+        Path('./tests/data/repo_with_2gitignore/folder/.gitignore'),
+    ]
+
+    result = cpp_stats.file_sieve._locate_file(repo_with_2gitignore, file_to_locate, [])
+
+    assert correct == result
+
+def test_find_gitignore_with_banned_dir_1(repo_with_2gitignore: Path):
+    '''
+    Tests that in repository with .gitignore 
+    function src.cpp_stats.file_sieve._locate_file finds exactly one
+    '''
+    file_to_locate = '.gitignore'
+    banned_dirs = [
+        Path('./tests/data/repo_with_2gitignore/folder/')
+    ]
+    correct = [
+        Path('./tests/data/repo_with_2gitignore/.gitignore'),
+    ]
+
+    result = cpp_stats.file_sieve._locate_file(repo_with_2gitignore, file_to_locate, banned_dirs)
+
+    assert correct == result
+
+def test_list_gitignore_dirs_1(repo_with_gitignore: Path):
+    gitignore_path = repo_with_gitignore.joinpath('.gitignore')
+    correct = [
+        repo_with_gitignore.joinpath('ignored_dir/')
+    ]
+
+    result = cpp_stats.file_sieve._get_git_ignore_dirs(gitignore_path)
+
+    assert correct == result
+
+def test_list_gitignore_dirs_2(repo_with_2gitignore: Path):
+    gitignore_path = repo_with_2gitignore.joinpath('.gitignore')
+    correct = [
+        repo_with_2gitignore.joinpath('ignored_dir')
+    ]
+
+    result = cpp_stats.file_sieve._get_git_ignore_dirs(gitignore_path)
+
+    assert correct == result
+
+def test_list_gitignore_dirs_3(repo_with_2gitignore: Path):
+    gitignore_path = repo_with_2gitignore.joinpath('folder').joinpath('.gitignore')
+    correct = [
+        repo_with_2gitignore.joinpath('folder').joinpath('ignored_dir')
+    ]
+
+    result = cpp_stats.file_sieve._get_git_ignore_dirs(gitignore_path)
+
+    assert correct == result
+
+def test_list_git_modules_dirs_1(repo_with_ignr_modules: Path):
+    gitmodules_path = repo_with_ignr_modules.joinpath('.gitmodules')
+    correct = [
+        repo_with_ignr_modules.joinpath('submodule1'),
+        repo_with_ignr_modules.joinpath('submodule2')
+    ]
+
+    result = cpp_stats.file_sieve._get_git_modules_dirs(gitmodules_path)
 
     assert correct == result

--- a/tests/test_file_sieve.py
+++ b/tests/test_file_sieve.py
@@ -181,6 +181,7 @@ def test_sieve_c_cxx_files_4(repo_with_ignr_modules: Path):
     '''
     expected = [
         repo_with_ignr_modules.joinpath('main.cpp'),
+        repo_with_ignr_modules.joinpath('src').joinpath('serial_port.c'),
         repo_with_ignr_modules.joinpath('src').joinpath('class.hpp'),
     ]
 

--- a/tests/test_file_sieve.py
+++ b/tests/test_file_sieve.py
@@ -1,9 +1,20 @@
-import pytest
+'''
+Tests module file_sieve.py
+'''
+
 from pathlib import Path
+import pytest
 
 import cpp_stats.file_sieve
 
 def assert_lists_equal_unordered(expected, actual):
+    '''
+    Asserts that two lists contain same elements.
+    
+    Parameters:
+    `expected` (list): Expected list.
+    `actual` (list): List to check.
+    '''
     assert sorted(expected) == sorted(actual), f"Expected: {expected}, Actual: {actual}"
 
 def rename_git_ignore_and_modules(repo_path: Path, to_test: bool = True):
@@ -66,136 +77,192 @@ def repo_with_ignr_modules():
 
 def test_find_gitignore_1(repo: Path):
     '''
-    Tests that in repository without .gitignore 
-    function src.cpp_stats.file_sieve._locate_file does not locate one
+    Tests that in repository without `.gitignore`
+    function `src.cpp_stats.file_sieve._locate_file`
+    does not locate any `.gitignore` files
     '''
     file_to_locate = '.gitignore'
-    correct = []
+    expected = []
 
-    result = cpp_stats.file_sieve._locate_file(repo, file_to_locate, [])
+    actual = cpp_stats.file_sieve._locate_file(repo, file_to_locate, [])
 
-    assert_lists_equal_unordered(correct, result)
+    assert_lists_equal_unordered(expected, actual)
 
 def test_find_gitignore_2(repo_with_gitignore: Path):
     '''
-    Tests that in repository with .gitignore 
-    function src.cpp_stats.file_sieve._locate_file finds exactly one
+    Tests that in repository with `.gitignore`
+    function `src.cpp_stats.file_sieve._locate_file` 
+    finds exactly one `.gitignore` file.
     '''
     file_to_locate = '.gitignore'
-    correct = [
+    expected = [
         Path('./tests/data/repo_with_gitignore/.gitignore')
     ]
 
-    result = cpp_stats.file_sieve._locate_file(repo_with_gitignore, file_to_locate, [])
+    actual = cpp_stats.file_sieve._locate_file(repo_with_gitignore, file_to_locate, [])
 
-    assert_lists_equal_unordered(correct, result)
+    assert_lists_equal_unordered(expected, actual)
 
 def test_find_gitignore_3(repo_with_2gitignore: Path):
     '''
-    Tests that in repository with .gitignore 
-    function src.cpp_stats.file_sieve._locate_file finds exactly one
+    Tests that in repository with `.gitignore`
+    function `src.cpp_stats.file_sieve._locate_file` 
+    finds exactly one `.gitignore`.
     '''
     file_to_locate = '.gitignore'
-    correct = [
+    expected = [
         Path('./tests/data/repo_with_2gitignore/.gitignore'),
         Path('./tests/data/repo_with_2gitignore/folder/.gitignore'),
     ]
 
-    result = cpp_stats.file_sieve._locate_file(repo_with_2gitignore, file_to_locate, [])
+    actual = cpp_stats.file_sieve._locate_file(repo_with_2gitignore, file_to_locate, [])
 
-    assert_lists_equal_unordered(correct, result)
+    assert_lists_equal_unordered(expected, actual)
 
 def test_find_gitignore_with_banned_dir_1(repo_with_2gitignore: Path):
     '''
-    Tests that in repository with .gitignore 
-    function src.cpp_stats.file_sieve._locate_file finds exactly one
+    Tests that in repository with banned directories and `.gitignore`
+    function `src.cpp_stats.file_sieve._locate_file` 
+    finds exactly one
     '''
     file_to_locate = '.gitignore'
     banned_dirs = [
         Path('./tests/data/repo_with_2gitignore/folder/')
     ]
-    correct = [
+    expected = [
         Path('./tests/data/repo_with_2gitignore/.gitignore'),
     ]
 
-    result = cpp_stats.file_sieve._locate_file(repo_with_2gitignore, file_to_locate, banned_dirs)
+    actual = cpp_stats.file_sieve._locate_file(repo_with_2gitignore, file_to_locate, banned_dirs)
 
-    assert_lists_equal_unordered(correct, result)
+    assert_lists_equal_unordered(expected, actual)
 
 def test_list_gitignore_dirs_1(repo_with_gitignore: Path):
+    '''
+    Tests that in repository with `.gitignore`
+    function `src.cpp_stats.file_sieve._get_git_ignore_dirs` 
+    finds all ignored dirs
+    '''
     gitignore_path = repo_with_gitignore.joinpath('.gitignore')
-    correct = [
+    expected = [
         repo_with_gitignore.joinpath('ignored_dir/')
     ]
 
-    result = cpp_stats.file_sieve._get_git_ignore_dirs(gitignore_path)
+    actual = cpp_stats.file_sieve._get_git_ignore_dirs(gitignore_path)
 
-    assert_lists_equal_unordered(correct, result)
+    assert_lists_equal_unordered(expected, actual)
 
 def test_list_gitignore_dirs_2(repo_with_2gitignore: Path):
+    '''
+    Tests that in repository with `.gitignore`
+    function `src.cpp_stats.file_sieve._get_git_ignore_dirs`
+    finds all ingored dirs.
+    '''
     gitignore_path = repo_with_2gitignore.joinpath('.gitignore')
-    correct = [
+    expected = [
         repo_with_2gitignore.joinpath('ignored_dir')
     ]
 
-    result = cpp_stats.file_sieve._get_git_ignore_dirs(gitignore_path)
+    actual = cpp_stats.file_sieve._get_git_ignore_dirs(gitignore_path)
 
-    assert_lists_equal_unordered(correct, result)
+    assert_lists_equal_unordered(expected, actual)
 
 def test_list_gitignore_dirs_3(repo_with_2gitignore: Path):
+    '''
+    Tests that in repository with nested `.gitignore`
+    function `src.cpp_stats.file_sieve._get_git_ignore_dirs`
+    finds all ingored dirs.
+    '''
     gitignore_path = repo_with_2gitignore.joinpath('folder').joinpath('.gitignore')
-    correct = [
+    expected = [
         repo_with_2gitignore.joinpath('folder').joinpath('ignored_dir')
     ]
 
-    result = cpp_stats.file_sieve._get_git_ignore_dirs(gitignore_path)
+    actual = cpp_stats.file_sieve._get_git_ignore_dirs(gitignore_path)
 
-    assert_lists_equal_unordered(correct, result)
+    assert_lists_equal_unordered(expected, actual)
 
 def test_list_git_modules_dirs_1(repo_with_ignr_modules: Path):
+    '''
+    Tests that in repository with `.gitmodules` 
+    function `src.cpp_stats.file_sieve._get_git_modules_dirs`
+    finds all submodules.
+    '''
     gitmodules_path = repo_with_ignr_modules.joinpath('.gitmodules')
-    correct = [
+    expected = [
         repo_with_ignr_modules.joinpath('submodule1'),
         repo_with_ignr_modules.joinpath('submodule2')
     ]
 
-    result = cpp_stats.file_sieve._get_git_modules_dirs(gitmodules_path)
+    actual = cpp_stats.file_sieve._get_git_modules_dirs(gitmodules_path)
 
-    assert_lists_equal_unordered(correct, result)
+    assert_lists_equal_unordered(expected, actual)
 
 def test_sieve_c_cxx_files_1(repo: Path):
-    correct = [
+    '''
+    Tests that
+    function `src.cpp_stats.file_sieve.sieve_c_cxx_files`
+    finds all C/C++ files.
+    '''
+    expected = [
         repo.joinpath('main.cpp')
     ]
 
-    result = cpp_stats.file_sieve.sieve_c_cxx_files(repo)
+    actual = cpp_stats.file_sieve.sieve_c_cxx_files(repo)
 
-    assert_lists_equal_unordered(correct, result)
+    assert_lists_equal_unordered(expected, actual)
 
 def test_sieve_c_cxx_files_2(repo_with_gitignore: Path):
-    correct = [
+    '''
+    Tests that in repository with `.gitignore`
+    function `src.cpp_stats.file_sieve.sieve_c_cxx_files`
+    finds all not ignored C/C++ files.
+    '''
+    expected = [
         repo_with_gitignore.joinpath('main.cpp')
     ]
 
-    result = cpp_stats.file_sieve.sieve_c_cxx_files(repo_with_gitignore)
+    actual = cpp_stats.file_sieve.sieve_c_cxx_files(repo_with_gitignore)
 
-    assert_lists_equal_unordered(correct, result)
+    assert_lists_equal_unordered(expected, actual)
 
 def test_sieve_c_cxx_files_3(repo_with_2gitignore: Path):
-    correct = [
+    '''
+    Tests that in repository with `.gitignore`
+    function `src.cpp_stats.file_sieve.sieve_c_cxx_files`
+    finds all not ignored C/C++ files.
+    '''
+    expected = [
         repo_with_2gitignore.joinpath('main.cpp')
     ]
 
-    result = cpp_stats.file_sieve.sieve_c_cxx_files(repo_with_2gitignore)
+    actual = cpp_stats.file_sieve.sieve_c_cxx_files(repo_with_2gitignore)
 
-    assert_lists_equal_unordered(correct, result)
+    assert_lists_equal_unordered(expected, actual)
 
 def test_sieve_c_cxx_files_4(repo_with_ignr_modules: Path):
-    correct = [
+    '''
+    Tests that in repository with `.gitignore` and `.gitmodules`
+    function `src.cpp_stats.file_sieve.sieve_c_cxx_files`
+    finds all not ignored C/C++ files.
+    '''
+    expected = [
         repo_with_ignr_modules.joinpath('main.cpp'),
         repo_with_ignr_modules.joinpath('src').joinpath('class.hpp'),
     ]
 
-    result = cpp_stats.file_sieve.sieve_c_cxx_files(repo_with_ignr_modules)
+    actual = cpp_stats.file_sieve.sieve_c_cxx_files(repo_with_ignr_modules)
 
-    assert_lists_equal_unordered(correct, result)
+    assert_lists_equal_unordered(expected, actual)
+
+def test_sieve_c_cxx_files_none():
+    '''
+    Tests that
+    function `src.cpp_stats.file_sieve.sieve_c_cxx_files`
+    return None when `repo_path` is None.
+    '''
+    expected = None
+
+    actual = cpp_stats.file_sieve.sieve_c_cxx_files(None)
+
+    assert expected == actual

--- a/tests/test_file_sieve.py
+++ b/tests/test_file_sieve.py
@@ -3,6 +3,9 @@ from pathlib import Path
 
 import cpp_stats.file_sieve
 
+def assert_lists_equal_unordered(expected, actual):
+    assert sorted(expected) == sorted(actual), f"Expected: {expected}, Actual: {actual}"
+
 def rename_git_ignore_and_modules(repo_path: Path, to_test: bool = True):
     '''
     Renames `test.gitignore` to `.gitignore` and 
@@ -71,7 +74,7 @@ def test_find_gitignore_1(repo: Path):
 
     result = cpp_stats.file_sieve._locate_file(repo, file_to_locate, [])
 
-    assert correct == result
+    assert_lists_equal_unordered(correct, result)
 
 def test_find_gitignore_2(repo_with_gitignore: Path):
     '''
@@ -85,7 +88,7 @@ def test_find_gitignore_2(repo_with_gitignore: Path):
 
     result = cpp_stats.file_sieve._locate_file(repo_with_gitignore, file_to_locate, [])
 
-    assert correct == result
+    assert_lists_equal_unordered(correct, result)
 
 def test_find_gitignore_3(repo_with_2gitignore: Path):
     '''
@@ -100,7 +103,7 @@ def test_find_gitignore_3(repo_with_2gitignore: Path):
 
     result = cpp_stats.file_sieve._locate_file(repo_with_2gitignore, file_to_locate, [])
 
-    assert correct == result
+    assert_lists_equal_unordered(correct, result)
 
 def test_find_gitignore_with_banned_dir_1(repo_with_2gitignore: Path):
     '''
@@ -117,7 +120,7 @@ def test_find_gitignore_with_banned_dir_1(repo_with_2gitignore: Path):
 
     result = cpp_stats.file_sieve._locate_file(repo_with_2gitignore, file_to_locate, banned_dirs)
 
-    assert correct == result
+    assert_lists_equal_unordered(correct, result)
 
 def test_list_gitignore_dirs_1(repo_with_gitignore: Path):
     gitignore_path = repo_with_gitignore.joinpath('.gitignore')
@@ -127,7 +130,7 @@ def test_list_gitignore_dirs_1(repo_with_gitignore: Path):
 
     result = cpp_stats.file_sieve._get_git_ignore_dirs(gitignore_path)
 
-    assert correct == result
+    assert_lists_equal_unordered(correct, result)
 
 def test_list_gitignore_dirs_2(repo_with_2gitignore: Path):
     gitignore_path = repo_with_2gitignore.joinpath('.gitignore')
@@ -137,7 +140,7 @@ def test_list_gitignore_dirs_2(repo_with_2gitignore: Path):
 
     result = cpp_stats.file_sieve._get_git_ignore_dirs(gitignore_path)
 
-    assert correct == result
+    assert_lists_equal_unordered(correct, result)
 
 def test_list_gitignore_dirs_3(repo_with_2gitignore: Path):
     gitignore_path = repo_with_2gitignore.joinpath('folder').joinpath('.gitignore')
@@ -147,7 +150,7 @@ def test_list_gitignore_dirs_3(repo_with_2gitignore: Path):
 
     result = cpp_stats.file_sieve._get_git_ignore_dirs(gitignore_path)
 
-    assert correct == result
+    assert_lists_equal_unordered(correct, result)
 
 def test_list_git_modules_dirs_1(repo_with_ignr_modules: Path):
     gitmodules_path = repo_with_ignr_modules.joinpath('.gitmodules')
@@ -158,4 +161,41 @@ def test_list_git_modules_dirs_1(repo_with_ignr_modules: Path):
 
     result = cpp_stats.file_sieve._get_git_modules_dirs(gitmodules_path)
 
-    assert correct == result
+    assert_lists_equal_unordered(correct, result)
+
+def test_sieve_c_cxx_files_1(repo: Path):
+    correct = [
+        repo.joinpath('main.cpp')
+    ]
+
+    result = cpp_stats.file_sieve.sieve_c_cxx_files(repo)
+
+    assert_lists_equal_unordered(correct, result)
+
+def test_sieve_c_cxx_files_2(repo_with_gitignore: Path):
+    correct = [
+        repo_with_gitignore.joinpath('main.cpp')
+    ]
+
+    result = cpp_stats.file_sieve.sieve_c_cxx_files(repo_with_gitignore)
+
+    assert_lists_equal_unordered(correct, result)
+
+def test_sieve_c_cxx_files_3(repo_with_2gitignore: Path):
+    correct = [
+        repo_with_2gitignore.joinpath('main.cpp')
+    ]
+
+    result = cpp_stats.file_sieve.sieve_c_cxx_files(repo_with_2gitignore)
+
+    assert_lists_equal_unordered(correct, result)
+
+def test_sieve_c_cxx_files_4(repo_with_ignr_modules: Path):
+    correct = [
+        repo_with_ignr_modules.joinpath('main.cpp'),
+        repo_with_ignr_modules.joinpath('src').joinpath('class.hpp'),
+    ]
+
+    result = cpp_stats.file_sieve.sieve_c_cxx_files(repo_with_ignr_modules)
+
+    assert_lists_equal_unordered(correct, result)

--- a/tests/test_file_sieve.py
+++ b/tests/test_file_sieve.py
@@ -1,0 +1,65 @@
+from pathlib import Path
+import src.cpp_stats.file_sieve
+
+import pytest
+
+def rename_gitignore(repo_path: Path, to_test: bool = True):
+    '''
+    Renames `test.gitignore` to `.gitignore` if `to_test == False` or
+    
+    renames `.gitignore` to `test.gitignore` if `to_test == True`
+    '''
+    if to_test:
+        for entry in repo_path.iterdir():
+            if entry.name == '.gitignore':
+                entry.rename(repo_path.joinpath('test.gitignore'))
+    else:
+        for entry in repo_path.iterdir():
+            if entry.name == 'test.gitignore':
+                entry.rename(repo_path.joinpath('.gitignore'))
+
+@pytest.fixture
+def repo():
+    '''
+    Returns path to test repository located at `/tests/data/repo`
+    '''
+    repo_path = Path('./tests/data/repo')
+    rename_gitignore(repo_path, False)
+    yield repo_path
+    rename_gitignore(repo_path, True)
+
+@pytest.fixture
+def repo_with_gitignore():
+    '''
+    Returns path to test repository located at `/tests/data/repo_with_gitignore`
+    '''
+    repo_path = Path('./tests/data/repo_with_gitignore')
+    rename_gitignore(repo_path, False)
+    yield repo_path
+    rename_gitignore(repo_path, True)
+
+def test_find_gitignore_1(repo: Path):
+    '''
+    Tests that in repository without .gitignore 
+    function src.cpp_stats.file_sieve._locate_file does not locate one
+    '''
+    file_to_locate = '.gitignore'
+    correct = []
+
+    result = src.cpp_stats.file_sieve._locate_file(repo, file_to_locate, [])
+
+    assert correct == result
+
+def test_find_gitignore_2(repo_with_gitignore: Path):
+    '''
+    Tests that in repository with .gitignore 
+    function src.cpp_stats.file_sieve._locate_file finds exactly one
+    '''
+    file_to_locate = '.gitignore'
+    correct = [
+        Path('./tests/data/repo_with_gitignore/.gitignore')
+    ]
+
+    result = src.cpp_stats.file_sieve._locate_file(repo_with_gitignore, file_to_locate, [])
+
+    assert correct == result

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -1,0 +1,5 @@
+'''
+Utility files for testing
+'''
+
+import utils.asserts

--- a/tests/utils/asserts.py
+++ b/tests/utils/asserts.py
@@ -1,0 +1,13 @@
+'''
+Contains useful asserts.
+'''
+
+def assert_lists_equal_unordered(expected, actual):
+    '''
+    Asserts that two lists contain same elements.
+    
+    Parameters:
+    `expected` (list): Expected list.
+    `actual` (list): List to check.
+    '''
+    assert sorted(expected) == sorted(actual), f"Expected: {expected}, Actual: {actual}"


### PR DESCRIPTION
Implemented calculating of number of C/C++ files.

Included tests for main class `CppStats` and finding all C/C++ files.

Search Features:

- During search all files that does not have C/C++ extensions (`*.h`, `*.hpp`, `*.c`, `*.C`, `*.cc`, `*.cpp`, `*.CPP`, `*.c++`. `*.cp`, `*.cxx`) are viewed as not C/C++.
- C/C++ files that are located inside directories listed in `.gitignore` are ignored.
- C/C++ files that belong to submodules listed in `.gitmodules` are ignored since they are not directly related to analyzed repository.

